### PR TITLE
Don‘t allow empty title and empty content & Add private status display

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -3,6 +3,7 @@ const { PRIV } = global.Hydro.model.builtin; // 内置 Privilege 权限节点
 const pastebin = global.Hydro.model.pastebin; // 刚刚编写的pastebin模型
 const { NotFoundError } = global.Hydro.error;
 const { PermissionError } = global.Hydro.error;
+const { ValidationError } = global.Hydro.error;
 
 class PasteCreateHandler extends Handler {
     async get() {
@@ -14,6 +15,8 @@ class PasteCreateHandler extends Handler {
         content , 
         isprivate,
     }) {
+        if(title.trim().length<2)throw new ValidationError('title', "title is too short.");
+        if(content.trim().length<3)throw new ValidationError('content', "content is too short.");
         var p;
         if(isprivate==="on"){
             p=true;
@@ -42,6 +45,8 @@ class PasteEditHandler extends Handler {
         content , 
         isprivate ,
     }) {
+        if(title.trim().length<2)throw new ValidationError('title', "title is too short.");
+        if(content.trim().length<3)throw new ValidationError('content', "content is too short.");
         var p;
         if(isprivate==="on"){
             p=true;

--- a/templates/paste_manage.html
+++ b/templates/paste_manage.html
@@ -18,7 +18,11 @@
                 <tbody>
                     {%- for pdoc in doc -%}
                     <tr>
-                        <td><a href="/paste/show/{{pdoc._id}}" style="color:inherit">{{pdoc.title}}</a></td>
+                        {% if pdoc.isprivate == true %}
+                            <td><a href="/paste/show/{{pdoc._id}}" style="color:inherit">{{pdoc.title}}<span style="color: red;"> (私有)</span></a></td>
+                        {% else %}
+                            <td><a href="/paste/show/{{pdoc._id}}" style="color:inherit">{{pdoc.title}}</a></td>
+                        {% endif %}
                         <td>{{pdoc.time}}</td>
                         <td>
                             <a href="/paste/show/{{pdoc._id}}/edit">编辑</a>&nbsp;&nbsp;

--- a/templates/paste_show.html
+++ b/templates/paste_show.html
@@ -18,6 +18,9 @@
               <font color="gray" size="2px">
                 {{ doc.time }}&emsp;<span class="icon icon-user"></span> {{ doc.user }}
               </font>
+              {% if doc.isprivate == true %}
+                <span style="color: red;">(私有)</span>
+              {% endif %}
             </div>
           </div>
           <!--


### PR DESCRIPTION
Limit the length of titles and content to prevent empty titles or content.

